### PR TITLE
feat: fix nth-check vulnerability by adding npm overrides

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15903,15 +15903,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/svgo/node_modules/nth-check": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
-      "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "boolbase": "~1.0.0"
-      }
-    },
     "node_modules/svgo/node_modules/supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,9 @@
     "react-scripts": "5.0.1",
     "styled-components": "^5.3.6"
   },
+  "overrides": {
+    "nth-check": "^2.0.1"
+  },
   "browserslist": {
     "production": [
       ">0.2%",


### PR DESCRIPTION
# 通过 npm overrides 修复 nth-check 漏洞
## 问题描述
项目中存在一个安全漏洞，来源于依赖链： react-scripts → @svgr/webpack → @svgr/plugin-svgo → svgo → css-select → nth-check (版本 1.0.2)。该版本的 nth-check 存在一个已知的安全漏洞。

## 解决方案
本 PR 通过在 package.json 中添加 npm overrides 来强制使用 nth-check 的安全版本（2.0.1 或更高版本），从而解决此漏洞，而无需升级整个 react-scripts 包（它已经是最新版本 5.0.1）。

## 更改内容
- 在 frontend/package.json 中添加了 overrides 字段，强制 nth-check 使用安全版本
- 更新了 frontend/package-lock.json 以反映此更改
## 验证
- 运行 npm audit 确认 nth-check 漏洞已解决
- 应用程序正常编译和运行
这确保了项目安全性，同时保持了依赖关系的稳定性。