### PR TITLE
Fix detectUserLanguage default to English and add tests

### DIFF
--- a/backend/utils/helpers.js
+++ b/backend/utils/helpers.js
@@ -108,7 +108,8 @@ function detectUserLanguage(message) {
   if (chineseRegex.test(message)) {
     return 'zh';
   }
-  return 'zh';
+  // Default to English when no Chinese characters are detected
+  return 'en';
 }
 
 // 引入系统提示词配置

--- a/tests/unit/helpers.test.js
+++ b/tests/unit/helpers.test.js
@@ -1,0 +1,11 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { detectUserLanguage } = require('../../backend/utils/helpers');
+
+test('detectUserLanguage returns zh when message contains Chinese characters', () => {
+  assert.strictEqual(detectUserLanguage('你好，世界'), 'zh');
+});
+
+test('detectUserLanguage returns en when message is in English', () => {
+  assert.strictEqual(detectUserLanguage('Hello world'), 'en');
+});


### PR DESCRIPTION
## Summary
- ensure detectUserLanguage defaults to English when no Chinese chars are found
- add unit tests covering language detection

## Testing
- `node --test tests/unit/helpers.test.js`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6896dd6c3c18832eb4995132b15000ff