### PR TITLE
Import helper functions for API URL validation

### DIFF
--- a/backend/routes/configure.js
+++ b/backend/routes/configure.js
@@ -3,6 +3,7 @@ const router = express.Router();
 
 // Import middleware
 const { securityMiddleware } = require('../middleware/security');
+const { validateApiUrl, sanitizeUrl } = require('../utils/helpers');
 
 // Configure API settings endpoint
 router.post('/', securityMiddleware, (req, res) => {


### PR DESCRIPTION
## Summary
- add missing helper import to `configure` route so `validateApiUrl` and `sanitizeUrl` are available

## Testing
- `npm test` (fails: Missing script "test")
- `(cd backend && npm test)` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_6896dfe13e90832eb6f5c059ccfd56fb