### PR TITLE
Use DELETE for reset endpoint

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -48,7 +48,7 @@ backend/
 
 - `POST /api/chat` - Send a message to the AI
 - `GET /api/conversation/:userId` - Get conversation history for a user
-- `POST /api/reset/:userId` - Reset conversation history for a user
+- `DELETE /api/reset/:userId` - Reset conversation history for a user
 - `POST /api/configure` - Configure API settings
 - `GET /api/export/:userId` - Export user data
 - `POST /api/import/:userId` - Import user data

--- a/backend/routes/reset.js
+++ b/backend/routes/reset.js
@@ -5,7 +5,7 @@ const router = express.Router();
 const { resetUserConversation } = require('../utils/helpers');
 
 // Reset conversation endpoint
-router.post('/:userId', (req, res) => {
+router.delete('/:userId', (req, res) => {
   const { userId } = req.params;
   
   if (!userId) {

--- a/backend/server.js
+++ b/backend/server.js
@@ -106,7 +106,7 @@ app.get('/api/docs', (req, res) => {
     endpoints: {
       'POST /api/chat': 'Send a message to the AI',
       'GET /api/conversation/:userId': 'Get conversation history for a user',
-      'POST /api/reset/:userId': 'Reset conversation history for a user',
+      'DELETE /api/reset/:userId': 'Reset conversation history for a user',
       'POST /api/configure': 'Configure API settings',
       'GET /api/export/:userId': 'Export user data',
       'POST /api/import/:userId': 'Import user data',

--- a/tests/unit/api-docs.test.js
+++ b/tests/unit/api-docs.test.js
@@ -1,0 +1,14 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+
+test('server documentation uses DELETE for reset endpoint', () => {
+  const serverPath = path.join(__dirname, '../../backend/server.js');
+  const content = fs.readFileSync(serverPath, 'utf8');
+  assert.ok(
+    content.includes("'DELETE /api/reset/:userId': 'Reset conversation history for a user'"),
+    'API docs should mention DELETE /api/reset/:userId'
+  );
+});
+


### PR DESCRIPTION
## Summary
- Switch reset route to DELETE to match documentation
- Update API docs and backend README to show DELETE method
- Add unit test verifying docs mention the DELETE reset endpoint

## Testing
- `node --test tests/unit/*.js`
- `npx playwright test tests/e2e/generatedtest_71382bf3-09bb-4c8b-a5dc-1f56d9544522.spec.ts --reporter=list` *(fails: Cannot find module '@playwright/test')*
- `npm install --no-save @playwright/test` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6896e0182620832e86c14a85db3e3491