### PR TITLE
test: streamline navigation and assert page load

### DIFF
--- a/tests/e2e/generatedtest_71382bf3-09bb-4c8b-a5dc-1f56d9544522.spec.ts
+++ b/tests/e2e/generatedtest_71382bf3-09bb-4c8b-a5dc-1f56d9544522.spec.ts
@@ -3,13 +3,13 @@ import { test } from '@playwright/test';
 import { expect } from '@playwright/test';
 
 test('GeneratedTest_2025-08-05', async ({ page, context }) => {
-  
+
     // Navigate to URL
     await page.goto('http://localhost:3000/');
 
-    // Navigate to URL
+    // Navigate to the application and wait for it to load
     await page.goto('http://localhost:3001/', { waitUntil: 'load' });
 
-    // Navigate to URL
-    await page.goto('http://localhost:3001/', { waitUntil: 'load' });
+    // Verify that the page loaded successfully
+    await expect(page).toHaveURL('http://localhost:3001/');
 });


### PR DESCRIPTION
## Summary
- remove redundant navigation to localhost:3001 in e2e test
- verify page load using toHaveURL assertion

## Testing
- `npx playwright test tests/e2e/generatedtest_71382bf3-09bb-4c8b-a5dc-1f56d9544522.spec.ts` *(fails: Cannot find module '@playwright/test')*

------
https://chatgpt.com/codex/tasks/task_e_6896e0c8851c832e95829ef205bb50e7