### PR TITLE
Fix reset endpoint method and missing imports

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -48,7 +48,7 @@ backend/
 
 - `POST /api/chat` - Send a message to the AI
 - `GET /api/conversation/:userId` - Get conversation history for a user
-- `POST /api/reset/:userId` - Reset conversation history for a user
+- `DELETE /api/reset/:userId` - Reset conversation history for a user
 - `POST /api/configure` - Configure API settings
 - `GET /api/export/:userId` - Export user data
 - `POST /api/import/:userId` - Import user data

--- a/backend/routes/configure.js
+++ b/backend/routes/configure.js
@@ -3,6 +3,8 @@ const router = express.Router();
 
 // Import middleware
 const { securityMiddleware } = require('../middleware/security');
+// Import helper functions
+const { validateApiUrl, sanitizeUrl } = require('../utils/helpers');
 
 // Configure API settings endpoint
 router.post('/', securityMiddleware, (req, res) => {

--- a/backend/routes/reset.js
+++ b/backend/routes/reset.js
@@ -5,7 +5,7 @@ const router = express.Router();
 const { resetUserConversation } = require('../utils/helpers');
 
 // Reset conversation endpoint
-router.post('/:userId', (req, res) => {
+router.delete('/:userId', (req, res) => {
   const { userId } = req.params;
   
   if (!userId) {

--- a/backend/server.js
+++ b/backend/server.js
@@ -106,7 +106,7 @@ app.get('/api/docs', (req, res) => {
     endpoints: {
       'POST /api/chat': 'Send a message to the AI',
       'GET /api/conversation/:userId': 'Get conversation history for a user',
-      'POST /api/reset/:userId': 'Reset conversation history for a user',
+      'DELETE /api/reset/:userId': 'Reset conversation history for a user',
       'POST /api/configure': 'Configure API settings',
       'GET /api/export/:userId': 'Export user data',
       'POST /api/import/:userId': 'Import user data',

--- a/backend/utils/helpers.js
+++ b/backend/utils/helpers.js
@@ -82,6 +82,12 @@ const getUserConversation = (userId) => {
   return userConversations[userId];
 };
 
+// Reset conversation history and context for a user
+const resetUserConversation = (userId) => {
+  delete userConversations[userId];
+  userContexts.delete(userId);
+};
+
 // 获取用户上下文
 function getUserContext(userId) {
   if (!userContexts.has(userId)) {
@@ -124,6 +130,7 @@ module.exports = {
   sanitizeUrl,
   validateApiUrl,
   getUserConversation,
+  resetUserConversation,
   getUserContext,
   updateUserContext,
   detectUserLanguage,

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -183,7 +183,7 @@
 - `POST /api/configure` - Configure user API keys
 - `POST /api/chat` - Send messages to AI model
 - `GET /api/conversation/:userId` - Get user conversation history
-- `DELETE /api/reset/:userId` - Reset API keys and conversation history
+- `DELETE /api/reset/:userId` - Reset conversation history for a user
 - `PUT /api/settings/:userId` - Save user settings
 - `GET /api/settings/:userId` - Get user settings
 - `GET /api/export/:userId` - Export user data

--- a/tests/e2e/generatedtest_71382bf3-09bb-4c8b-a5dc-1f56d9544522.spec.ts
+++ b/tests/e2e/generatedtest_71382bf3-09bb-4c8b-a5dc-1f56d9544522.spec.ts
@@ -1,15 +1,14 @@
 
-import { test } from '@playwright/test';
-import { expect } from '@playwright/test';
+import { test, expect } from '@playwright/test';
 
 test('GeneratedTest_2025-08-05', async ({ page, context }) => {
   
-    // Navigate to URL
+    // Navigate to initial URL
     await page.goto('http://localhost:3000/');
 
-    // Navigate to URL
+    // Navigate to target URL
     await page.goto('http://localhost:3001/', { waitUntil: 'load' });
 
-    // Navigate to URL
-    await page.goto('http://localhost:3001/', { waitUntil: 'load' });
+    // Verify the page loaded successfully
+    await expect(page).toHaveURL('http://localhost:3001/');
 });

--- a/tests/unit/helpers.test.js
+++ b/tests/unit/helpers.test.js
@@ -1,6 +1,11 @@
 const test = require('node:test');
 const assert = require('node:assert');
-const { detectUserLanguage } = require('../../backend/utils/helpers');
+const {
+  detectUserLanguage,
+  getUserConversation,
+  getUserContext,
+  resetUserConversation,
+} = require('../../backend/utils/helpers');
 
 test('detectUserLanguage returns zh when message contains Chinese characters', () => {
   assert.strictEqual(detectUserLanguage('你好，世界'), 'zh');
@@ -8,4 +13,16 @@ test('detectUserLanguage returns zh when message contains Chinese characters', (
 
 test('detectUserLanguage returns en when message is in English', () => {
   assert.strictEqual(detectUserLanguage('Hello world'), 'en');
+});
+
+test('resetUserConversation clears stored data for user', () => {
+  const userId = 'test-user';
+  // Prime conversation and context
+  getUserConversation(userId).push({ sender: 'user', text: 'hi' });
+  getUserContext(userId).messages.push({ role: 'user', content: 'hi' });
+
+  resetUserConversation(userId);
+
+  assert.deepStrictEqual(getUserConversation(userId), []);
+  assert.deepStrictEqual(getUserContext(userId).messages, []);
 });


### PR DESCRIPTION
## Summary
- add missing helper imports in configure route
- switch reset endpoint to DELETE and update docs
- streamline E2E test with a real assertion
- define resetUserConversation helper and test; correct docs for reset endpoint

## Testing
- `node --test tests/unit/helpers.test.js`
- `npx playwright test tests/e2e/generatedtest_71382bf3-09bb-4c8b-a5dc-1f56d9544522.spec.ts` *(fails: Cannot find module '@playwright/test')*

------
https://chatgpt.com/codex/tasks/task_e_6896dd6e34b4832eae826000a3daf037